### PR TITLE
FTR-116: Notification server starts on fixed port number

### DIFF
--- a/src/main/kotlin/hr/foi/servicesync/config/PortListener.kt
+++ b/src/main/kotlin/hr/foi/servicesync/config/PortListener.kt
@@ -1,0 +1,14 @@
+package hr.foi.servicesync.config
+
+import org.springframework.boot.web.context.WebServerInitializedEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class PortListener {
+    @EventListener
+    fun onApplicationStart(event: WebServerInitializedEvent) {
+        val port = event.webServer.port
+        println("ServiceSync Notification Server is running on port: ${port}")
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=ServiceSync-Notification-Server
+server.port=0


### PR DESCRIPTION
- added "server.port = 0" to application.properties so that the notification server searches available ports and uses one to start it
- added PortListener with method onApplicationStart that prints on which port the notification server was started for easier future debugging